### PR TITLE
API refactor

### DIFF
--- a/api_schema.yml
+++ b/api_schema.yml
@@ -8,16 +8,29 @@ definitions:
     pattern: "^([a-z0-9]+\.)+hashbang\.sh$"
 
   captcha:
-    description: CAPTCHA descriptor
-    type: object
-    required: [challenge, token]
-    properties:
-      challenge:
-        type: string
-        description: Human-readable challenge
-      token:
-        type: string
-        description: Opaque challenge descriptor
+    challenge:
+      description: CAPTCHA descriptor
+      type: object
+      required: [challenge, token]
+      properties:
+        challenge:
+          type: string
+          description: Human-readable challenge
+        token:
+          type: string
+          description: Opaque challenge descriptor
+
+    response:
+      description: CAPTCHA solution
+      type: object
+      required: [token, answer]
+      properties:
+        token:
+          type: string
+          description: Opaque challenge descriptor
+        answer:
+          type: string
+          description: Solution of the text-based CAPTCHA
 
   create_user:
     type: object
@@ -40,7 +53,7 @@ links:
   - description: Request a one-time CAPTCHA
     href: /captcha
     method: POST
-    targetSchema: {$ref: "#/definitions/captcha"}
+    targetSchema: {$ref: "#/definitions/captcha/challenge"}
     schema:
       type: object
       required: [user]

--- a/api_schema.yml
+++ b/api_schema.yml
@@ -7,18 +7,46 @@ definitions:
     type: string
     pattern: "^([a-z0-9]+\.)+hashbang\.sh$"
 
+  captcha:
+    description: CAPTCHA descriptor
+    type: object
+    required: [challenge, token]
+    properties:
+      challenge:
+        type: string
+        description: Human-readable challenge
+      token:
+        type: string
+        description: Opaque challenge descriptor
+
   create_user:
     type: object
-    required: [user, host, key]
+    required: [user, host, key, token, answer]
     properties:
       user: {$ref: "#/definitions/username"}
       host: {$ref: "#/definitions/hostname"}
       key:
         type: string
         description: "User's SSH key"
+      token:
+        type: string
+        description: Opaque challenge descriptor
+      answer:
+        type: string
+        description: Solution to the CAPTCHA
 
 
 links:
+  - description: Request a one-time CAPTCHA
+    href: /captcha
+    method: POST
+    targetSchema: {$ref: "#/definitions/captcha"}
+    schema:
+      type: object
+      required: [user]
+      properties:
+        user: {$ref: "#/definitions/username"}
+
   - description: Create a new user
     href: /user/create
     method: POST

--- a/api_schema.yml
+++ b/api_schema.yml
@@ -32,22 +32,6 @@ definitions:
           type: string
           description: Solution of the text-based CAPTCHA
 
-  create_user:
-    type: object
-    required: [user, host, key, token, answer]
-    properties:
-      user: {$ref: "#/definitions/username"}
-      host: {$ref: "#/definitions/hostname"}
-      key:
-        type: string
-        description: "User's SSH key"
-      token:
-        type: string
-        description: Opaque challenge descriptor
-      answer:
-        type: string
-        description: Solution to the CAPTCHA
-
 
 links:
   - description: Request a one-time CAPTCHA
@@ -63,7 +47,15 @@ links:
   - description: Create a new user
     href: /user/create
     method: POST
-    schema: {$ref: "#/definitions/create_user"}
+    schema:
+      type: object
+      required: [user, host]
+      properties:
+        user: {$ref: "#/definitions/username"}
+        host: {$ref: "#/definitions/hostname"}
+      allOf:
+        - $ref: "#/definitions/captcha/response"
+        - $ref: "data_user.yml"
 
   - description: Request server infos
     href: /server/stats

--- a/data_host.yml
+++ b/data_host.yml
@@ -17,7 +17,6 @@ properties:
       minimum: -180
       maximum:  180
     required: [lat, lon]
-    additionalProperties: False
 
   inet:
     description: "Server's IP address(es)"


### PR DESCRIPTION
This breaks backwards-compatibility (BC) pretty much all over the place.

- [x] Add [CAPTCHAs](https://github.com/hashbang/hashbang/blob/master/abuse/signup.md) for user registration. (BC)
- [x] Makes all the data- and API-schemas forward-compatible.  
  Only change needed was to allow extra properties in the hosts' `coordinates` object.
- [x] Simplify the user creation endpoint (BC), and let it set arbitrary user data when creating a user, including:
  - multiple SSH keys;
  - “distinguished name” (GECOS);
  - login shell.