### PR TITLE
Adds user ssh key validation

### DIFF
--- a/data_user.yml
+++ b/data_user.yml
@@ -18,6 +18,6 @@ definitions:
   ssh_key:
     type: string
     description: A valid rsa, dsa, or ecdsa key compatible with sshd.
-    pattern: '^(ssh-(rsa|dss|ed25519)|ecdsa-sha2-nistp(256|384|521)) [a-zA-Z0-9/+=]{8,}( .*)?[^\n]$'
+    pattern: '^(.+(,.+)* )?(ssh-(rsa|dss|ed25519)|ecdsa-sha2-nistp(256|384|521)) [a-zA-Z0-9/+=]{8,}( .*)?[^\n]$'
 
 required: [ssh_keys, shell]

--- a/data_user.yml
+++ b/data_user.yml
@@ -4,7 +4,7 @@ type: object
 properties:
   ssh_keys:
     type: array
-    items: {type: string}
+    items: {$ref: '#/definitions/ssh_key'}
     uniqueItems: True
     description: SSH keys for the shell servers
   name:
@@ -13,5 +13,11 @@ properties:
   shell:
     type: string
     description: "User's login shell"
+    
+definitions:
+  ssh_key:
+    type: string
+    description: A valid rsa, dsa, or ecdsa key compatible with sshd.
+    pattern: '^(ssh-(rsa|dss|ed25519)|ecdsa-sha2-nistp(256|384|521)) [a-zA-Z0-9/+=]{8,}( .*)?[^\n]$'
 
 required: [ssh_keys, shell]


### PR DESCRIPTION
This adds a pattern to the ssh key field to prevent bogons from entering.
Has a sibling commit [here](https://github.com/hashbang/userdb/commit/40b17b429494df9f0a83fa5f8bafa5afa54e063e)
Fixes #4 